### PR TITLE
Fix Playwright strict mode violation in E2E tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6549,3 +6549,12 @@ Upload artifacts on every CI run with `if: always()`; control payload via Playwr
 ### Next logical step
 
 Confirm first Actions run uploads `playwright-report` on green E2E and `vitest-coverage` on green fast job.
+
+---
+
+## 2026-06-21 — E2E adddescriptions blocklist strict mode fix
+
+`getByText(/wank|…/)` matched both the textarea value and the `WarningMessage` banner — Playwright strict mode violation. Assert the API substring message instead.
+
+- `e2e/adddescriptions.spec.ts`
+- `CHANGES.md`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6554,7 +6554,7 @@ Confirm first Actions run uploads `playwright-report` on green E2E and `vitest-c
 
 ## 2026-06-21 — E2E adddescriptions blocklist strict mode fix
 
-`getByText(/wank|…/)` matched both the textarea value and the `WarningMessage` banner — Playwright strict mode violation. Assert the API substring message instead.
+`getByText(/wank|…/)` matched both the textarea value and the `WarningMessage` banner — Playwright strict mode violation. Assert via 403 response + `p.bg-red-900` banner (API message for `wank` is banned-everywhere / blocklist wording, not substring phrase text).
 
 - `e2e/adddescriptions.spec.ts`
 - `CHANGES.md`

--- a/e2e/adddescriptions.spec.ts
+++ b/e2e/adddescriptions.spec.ts
@@ -64,7 +64,9 @@ test.describe("Add descriptions page (authenticated)", () => {
     );
     await submitDescriptionForm(page);
 
-    await expect(page.getByText(/wank|not allowed|blocklist/i)).toBeVisible({
+    await expect(
+      page.getByText(/any content containing the phrase wank is not allowed/i),
+    ).toBeVisible({
       timeout: 15_000,
     });
   });

--- a/e2e/adddescriptions.spec.ts
+++ b/e2e/adddescriptions.spec.ts
@@ -62,13 +62,25 @@ test.describe("Add descriptions page (authenticated)", () => {
       page,
       "This friendly dog wank test phrase is long enough",
     );
-    await submitDescriptionForm(page);
 
-    await expect(
-      page.getByText(/any content containing the phrase wank is not allowed/i),
-    ).toBeVisible({
-      timeout: 15_000,
-    });
+    const blockResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/description") &&
+        res.request().method() === "POST" &&
+        res.status() === 403,
+    );
+    await submitDescriptionForm(page);
+    const response = await blockResponse;
+    const body = (await response.json()) as {
+      message: string;
+      blockedBy: string;
+    };
+    expect(body.blockedBy).toBe("wank");
+
+    // WarningMessage banner only — textarea still contains "wank"
+    await expect(page.locator("p.bg-red-900").getByText(body.message)).toBeVisible(
+      { timeout: 15_000 },
+    );
   });
 
   test("check-if-exists flags duplicate at start of seeded description", async ({


### PR DESCRIPTION
 by updating text assertions in `adddescriptions.spec.ts`. Documented the change in `CHANGES.md` to reflect the new behavior of the test regarding blocklist phrases.